### PR TITLE
Set __packed attribute

### DIFF
--- a/headers/efi_pei_services_64.h
+++ b/headers/efi_pei_services_64.h
@@ -210,7 +210,7 @@ struct _EFI_PEI_NOTIFY_DESCRIPTOR {
     EFI_PEIM_NOTIFY_ENTRY_POINT Notify;
 };
 
-struct EFI_FV_FILE_INFO2 {
+struct EFI_FV_FILE_INFO2 __packed {
     EFI_GUID FileName;
     EFI_FV_FILETYPE FileType;
     EFI_FV_FILE_ATTRIBUTES FileAttributes;
@@ -219,7 +219,7 @@ struct EFI_FV_FILE_INFO2 {
     UINT32 AuthenticationStatus;
 };
 
-struct EFI_TABLE_HEADER {
+struct EFI_TABLE_HEADER __packed {
     UINT64 Signature;
     UINT32 Revision;
     UINT32 HeaderSize;

--- a/headers/efi_system_table_64.h
+++ b/headers/efi_system_table_64.h
@@ -26,7 +26,7 @@ typedef UINTN EFI_TPL;
 typedef unsigned int uint;
 
 /* 2025 */
-struct EFI_TABLE_HEADER
+struct EFI_TABLE_HEADER __packed
 {
   UINT64 Signature;
   UINT32 Revision;
@@ -438,7 +438,7 @@ struct EFI_DEVICE_PATH_PROTOCOL
 };
 
 /* 4443 */
-struct EFI_OPEN_PROTOCOL_INFORMATION_ENTRY
+struct EFI_OPEN_PROTOCOL_INFORMATION_ENTRY __packed
 {
   EFI_HANDLE AgentHandle;
   EFI_HANDLE ControllerHandle;


### PR DESCRIPTION
Prevent padding by adding __packed attribute to affected
structs.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>