### PR TITLE
Prevent padding 

### DIFF
--- a/headers/efi_pei_services_64.h
+++ b/headers/efi_pei_services_64.h
@@ -204,7 +204,7 @@ typedef enum enum_868 EFI_PEI_CPU_IO_PPI_WIDTH;
 
 typedef EFI_STATUS (* EFI_PEI_CPU_IO_PPI_IO_MEM)(EFI_PEI_SERVICES * *, EFI_PEI_CPU_IO_PPI *, EFI_PEI_CPU_IO_PPI_WIDTH, UINT64, UINTN, void *);
 
-struct _EFI_PEI_NOTIFY_DESCRIPTOR {
+struct _EFI_PEI_NOTIFY_DESCRIPTOR __packed {
     UINTN Flags;
     EFI_GUID * Guid;
     EFI_PEIM_NOTIFY_ENTRY_POINT Notify;
@@ -227,12 +227,12 @@ struct EFI_TABLE_HEADER __packed {
     UINT32 Reserved;
 };
 
-struct EFI_PEI_CPU_IO_PPI_ACCESS {
+struct EFI_PEI_CPU_IO_PPI_ACCESS __packed {
     EFI_PEI_CPU_IO_PPI_IO_MEM Read;
     EFI_PEI_CPU_IO_PPI_IO_MEM Write;
 };
 
-struct EFI_PEI_CPU_IO_PPI {
+struct EFI_PEI_CPU_IO_PPI __packed {
     struct EFI_PEI_CPU_IO_PPI_ACCESS Mem;
     struct EFI_PEI_CPU_IO_PPI_ACCESS Io;
     EFI_PEI_CPU_IO_PPI_IO_READ8 IoRead8;
@@ -253,7 +253,7 @@ struct EFI_PEI_CPU_IO_PPI {
     EFI_PEI_CPU_IO_PPI_MEM_WRITE64 MemWrite64;
 };
 
-struct EFI_FV_INFO {
+struct EFI_FV_INFO __packed {
     EFI_FVB_ATTRIBUTES_2 FvAttributes;
     EFI_GUID FvFormat;
     EFI_GUID FvName;
@@ -261,20 +261,20 @@ struct EFI_FV_INFO {
     UINT64 FvSize;
 };
 
-struct EFI_PEI_PCI_CFG2_PPI {
+struct EFI_PEI_PCI_CFG2_PPI __packed {
     EFI_PEI_PCI_CFG2_PPI_IO Read;
     EFI_PEI_PCI_CFG2_PPI_IO Write;
     EFI_PEI_PCI_CFG2_PPI_RW Modify;
     UINT16 Segment;
 };
 
-struct EFI_PEI_PPI_DESCRIPTOR {
+struct EFI_PEI_PPI_DESCRIPTOR __packed {
     UINTN Flags;
     EFI_GUID * Guid;
     void * Ppi;
 };
 
-struct EFI_FV_FILE_INFO {
+struct EFI_FV_FILE_INFO __packed {
     EFI_GUID FileName;
     EFI_FV_FILETYPE FileType;
     EFI_FV_FILE_ATTRIBUTES FileAttributes;
@@ -282,7 +282,7 @@ struct EFI_FV_FILE_INFO {
     UINT32 BufferSize;
 };
 
-struct _EFI_PEI_SERVICES {
+struct _EFI_PEI_SERVICES __packed {
     struct EFI_TABLE_HEADER Hdr;
     EFI_PEI_INSTALL_PPI InstallPpi;
     EFI_PEI_REINSTALL_PPI ReInstallPpi;
@@ -314,7 +314,7 @@ struct _EFI_PEI_SERVICES {
     EFI_PEI_FREE_PAGES FreePages;
 };
 
-struct EFI_STATUS_CODE_DATA {
+struct EFI_STATUS_CODE_DATA __packed {
     UINT16 HeaderSize;
     UINT16 Size;
     EFI_GUID Type;

--- a/headers/efi_system_table_64.h
+++ b/headers/efi_system_table_64.h
@@ -75,7 +75,12 @@ typedef EFI_STATUS (__fastcall *EFI_SET_VIRTUAL_ADDRESS_MAP)(UINTN, UINTN, UINT3
 typedef EFI_STATUS (__fastcall *EFI_CONVERT_POINTER)(UINTN, void **);
 
 /* 1710 */
-typedef GUID EFI_GUID;
+struct EFI_GUID __packed {
+  UINT32  Data1;
+  UINT16  Data2;
+  UINT16  Data3;
+  UINT8   Data4[8];
+};
 
 /* 4384 */
 typedef EFI_STATUS (__fastcall *EFI_GET_VARIABLE)(CHAR16 *, EFI_GUID *, UINT32 *, UINTN *, void *);

--- a/headers/efi_system_table_64.h
+++ b/headers/efi_system_table_64.h
@@ -39,7 +39,7 @@ struct EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
 struct EFI_SIMPLE_TEXT_INPUT_PROTOCOL;
 
 /* 4451 */
-struct EFI_SYSTEM_TABLE
+struct EFI_SYSTEM_TABLE __packed
 {
   struct EFI_TABLE_HEADER Hdr;
   CHAR16 *FirmwareVendor;
@@ -114,7 +114,7 @@ typedef EFI_STATUS (__fastcall *EFI_QUERY_CAPSULE_CAPABILITIES)(struct EFI_CAPSU
 typedef EFI_STATUS (__fastcall *EFI_QUERY_VARIABLE_INFO)(UINT32, UINT64 *, UINT64 *, UINT64 *);
 
 /* 4450 */
-struct EFI_RUNTIME_SERVICES
+struct EFI_RUNTIME_SERVICES __packed
 {
   struct EFI_TABLE_HEADER Hdr;
   EFI_GET_TIME GetTime;
@@ -330,7 +330,7 @@ typedef EFI_STATUS (* EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES)(EFI_HANDLE *, ..
 typedef EFI_STATUS (* EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)(EFI_HANDLE, ...);
 
 /* 4442 */
-struct EFI_BOOT_SERVICES
+struct EFI_BOOT_SERVICES __packed
 {
   struct EFI_TABLE_HEADER Hdr;
   EFI_RAISE_TPL RaiseTPL;
@@ -380,14 +380,14 @@ struct EFI_BOOT_SERVICES
 };
 
 /* 4447 */
-struct EFI_CONFIGURATION_TABLE
+struct EFI_CONFIGURATION_TABLE __packed
 {
   EFI_GUID VendorGuid;
   void *VendorTable;
 };
 
 /* 2796 */
-struct EFI_TIME
+struct EFI_TIME __packed
 {
   UINT16 Year;
   UINT8 Month;
@@ -403,7 +403,7 @@ struct EFI_TIME
 };
 
 /* 4449 */
-struct EFI_TIME_CAPABILITIES
+struct EFI_TIME_CAPABILITIES __packed
 {
   UINT32 Resolution;
   UINT32 Accuracy;
@@ -411,7 +411,7 @@ struct EFI_TIME_CAPABILITIES
 };
 
 /* 4444 */
-struct EFI_MEMORY_DESCRIPTOR
+struct EFI_MEMORY_DESCRIPTOR __packed
 {
   UINT32 Type;
   EFI_PHYSICAL_ADDRESS PhysicalStart;
@@ -421,7 +421,7 @@ struct EFI_MEMORY_DESCRIPTOR
 };
 
 /* 4446 */
-struct EFI_CAPSULE_HEADER
+struct EFI_CAPSULE_HEADER __packed
 {
   EFI_GUID CapsuleGuid;
   UINT32 HeaderSize;
@@ -430,7 +430,7 @@ struct EFI_CAPSULE_HEADER
 };
 
 /* 1773 */
-struct EFI_DEVICE_PATH_PROTOCOL
+struct EFI_DEVICE_PATH_PROTOCOL __packed
 {
   UINT8 Type;
   UINT8 SubType;


### PR DESCRIPTION
Analog to #7 set all remaining structs to packed.

Fixes #6.