### PR TITLE
support for 3.1 clang type parsing and a few other upcoming API deprecations

### DIFF
--- a/headers/efi_pei_services_64.h
+++ b/headers/efi_pei_services_64.h
@@ -11,6 +11,23 @@ typedef unsigned int    undefined4;
 typedef unsigned short    ushort;
 typedef unsigned short    word;
 
+typedef uint8_t BOOLEAN;
+typedef uint8_t UINT8;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef struct {
+  UINT32  Data1;
+  UINT16  Data2;
+  UINT16  Data3;
+  UINT8   Data4[8];
+} GUID;
+
+
 struct EFI_PEI_PPI_DESCRIPTOR;
 struct EFI_STATUS_CODE_DATA;
 struct EFI_FV_FILE_INFO;

--- a/headers/efi_system_table_64.h
+++ b/headers/efi_system_table_64.h
@@ -3,6 +3,22 @@
 #define __int32 int
 #define __int64 long long
 
+typedef uint8_t BOOLEAN;
+typedef uint8_t UINT8;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef struct {
+  UINT32  Data1;
+  UINT16  Data2;
+  UINT16  Data3;
+  UINT8   Data4[8];
+} GUID;
+
 struct EFI_DEVICE_PATH_PROTOCOL;
 struct EFI_TIME;
 struct EFI_BOOT_SERVICES;

--- a/teloader.py
+++ b/teloader.py
@@ -28,7 +28,7 @@ class TerseExecutableView(BinaryView):
         :return: True if the binary is a TE, otherwise False
         """
 
-        if len(data) < TERSE_IMAGE_HEADER_SIZE:
+        if data.length < TERSE_IMAGE_HEADER_SIZE:
             return False
 
         if data[0:2].decode('utf-8', 'replace') != 'VZ':


### PR DESCRIPTION
The main issue was the change in the header files. I assume it's the result of the 3.1 change to use clang for type parsing? Fairly easy fix though and the rest are just some small API changes that are either currently or will be soon deprecated.